### PR TITLE
Write pharos-result to github actions step-summary

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -192,6 +192,8 @@ runs:
           fi
 
         fi
+        
+        [[ ${_exit_code} -gt 0 ]] && _summary_prefix=":x: " || _summary_prefix=""
         echo "${_message}";
-        echo "${_message}" >> $GITHUB_STEP_SUMMARY;
+        echo "${_summary_prefix}${_message}" >> $GITHUB_STEP_SUMMARY;
         exit ${_exit_code};


### PR DESCRIPTION
Write result to step-summary to easier see the type of failure that caused the workflow to fail.

(Hide whitespace-diff when reviewing)


![Screenshot 2024-04-23 at 14 36 01](https://github.com/kartverket/pharos/assets/172572/84ed1877-450f-4016-bceb-091663ee28f3)
