### PR TITLE
Oppdaterer Trivy version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -92,7 +92,7 @@ runs:
         timeout: 15m
         skip-dirs: ${{ inputs.skip_dirs }}
         skip-files: ${{ inputs.skip_files }}
-        version: 'v0.67.0'
+        version: 'v0.69.2'
 
     - name: Upload SARIF file
       if: inputs.tfsec == 'true'


### PR DESCRIPTION
Følger føre-var prinsipp og oppdaterer Trivy til nyeste versjon etter det ble meldt om en kompromittert GitHub Actions‐flyt, dette skal ikke ha truffet oss, men oppdaterer for å være på den trygge siden. 